### PR TITLE
update reason1 field per sofort request

### DIFF
--- a/lib/offsite_payments/integrations/directebanking.rb
+++ b/lib/offsite_payments/integrations/directebanking.rb
@@ -46,7 +46,6 @@ module OffsitePayments #:nodoc:
         # credential4: Notification Password (Algorithm: SH1)
         def initialize(order, account, options = {})
           super
-          add_field('user_variable_0', order)
           add_field('project_id', options[:credential2])
           @project_password = options[:credential3]
         end
@@ -112,7 +111,7 @@ module OffsitePayments #:nodoc:
         mapping :account, 'user_id'
         mapping :amount, 'amount'
         mapping :currency, 'currency_id'
-        mapping :description, 'reason_1'
+        mapping :order, 'reason_1'
 
         mapping :return_url, 'user_variable_1'
         mapping :cancel_return_url, 'user_variable_2'

--- a/test/unit/integrations/directebanking/directebanking_helper_test.rb
+++ b/test/unit/integrations/directebanking/directebanking_helper_test.rb
@@ -23,19 +23,18 @@ class DirectebankingHelperTest < Test::Unit::TestCase
     assert_field 'user_id', 'UserID-24352435'
     assert_field 'project_id', 'ProjectID-1234'
     assert_field 'amount', '5.00'
-    assert_field 'user_variable_0', 'order-500'
-    assert_field 'reason_1', 'My order #1234'
+    assert_field 'reason_1', 'order-500'
   end
 
   def test_generate_signature_string
-    assert_equal "UserID-24352435|ProjectID-1234|||||5.00|EUR|||order-500|https://localhost:8080/directebanking|||||mysecretString",
+    assert_equal "UserID-24352435|ProjectID-1234|||||5.00|EUR|order-500|||https://localhost:8080/directebanking|||||mysecretString",
     @helper.generate_signature_string
   end
 
   def test_generate_signature
     assert !@helper.form_fields['hash'].empty?
-    assert_equal 'c34113bc04eb28a045fe5c2b1e9e186fe3cde03b', @helper.generate_signature
-    assert_equal "c34113bc04eb28a045fe5c2b1e9e186fe3cde03b", @helper.form_fields['hash']
+    assert_equal '669884aeab85fedb5ed4c9614d91fcf5dde19d9f', @helper.generate_signature
+    assert_equal "669884aeab85fedb5ed4c9614d91fcf5dde19d9f", @helper.form_fields['hash']
   end
 
   def test_unknown_mapping


### PR DESCRIPTION
SofortBanking (formerly directebanking) has asked us to stop submitting the description field (`shop.name` - `checkout.id`) as the `reason_1` field, as it's getting truncated, and is no longer unique. Instead we'll begin sending the `checkout.id` as the `reason_1` field, via `:order`.

Please review @odorcicd 