### PR TITLE
Add support for total_original Coinbase parameter

### DIFF
--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -81,7 +81,11 @@ module OffsitePayments #:nodoc:
         end
 
         def gross
-          "%.2f" % (params['total_native']['cents'].to_f / 100)
+          if params['total_original'].present?
+            "%.2f" % (params['total_original']['cents'].to_f / 100)
+          else
+            "%.2f" % (params['total_native']['cents'].to_f / 100)
+          end
         end
 
         def currency

--- a/test/unit/integrations/coinbase/coinbase_notification_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_notification_test.rb
@@ -17,6 +17,11 @@ class CoinbaseNotificationTest < Test::Unit::TestCase
     assert_equal 1404914433, @coinbase.received_at
   end
 
+  def test_total_original_support
+    coinbase = Coinbase::Notification.new(total_original_http_raw_data, { :credential1 => "key", :credential2 => "secret" })
+    assert_equal "0.01", coinbase.gross    
+  end
+
   def test_acknowledgement
     Net::HTTP.any_instance.expects(:request).returns(stub(:body => http_raw_data))
     assert @coinbase.acknowledge
@@ -35,5 +40,9 @@ class CoinbaseNotificationTest < Test::Unit::TestCase
 
   def conflicting_http_raw_data
     '{"order":{"id":"OQJ836AF","created_at":"2014-07-09T07:00:33-07:00","status":"failed","event":{"type":"completed"},"total_btc":{"cents":1463,"currency_iso":"BTC"},"total_native":{"cents":1,"currency_iso":"CAD"},"total_payout":{"cents":0,"currency_iso":"USD"},"custom":"10","receive_address":"19FuVxoEvVLxRibVnmSciNXEsfgFs8W29Z","button":{"type":"buy_now","name":"Shop One - #10","description":null,"id":"0c3e9c6dd38619a2ba11b4561631e6ad"},"refund_address":"1BmmrdqcLqGCtx54vvencNS8VCMsjJCEBA","transaction":{"id":"53bd4b0e86fd2456d8000003","hash":null,"confirmations":0}}}'
+  end
+  
+  def total_original_http_raw_data
+    '{"order":{"id":"OQJ836AF","created_at":"2014-07-09T07:00:33-07:00","status":"completed","event":{"type":"completed"},"total_btc":{"cents":1463,"currency_iso":"BTC"},"total_original":{"cents":1,"currency_iso":"CAD"},"total_payout":{"cents":0,"currency_iso":"USD"},"custom":"10","receive_address":"19FuVxoEvVLxRibVnmSciNXEsfgFs8W29Z","button":{"type":"buy_now","name":"Shop One - #10","description":null,"id":"0c3e9c6dd38619a2ba11b4561631e6ad"},"refund_address":"1BmmrdqcLqGCtx54vvencNS8VCMsjJCEBA","transaction":{"id":"53bd4b0e86fd2456d8000003","hash":null,"confirmations":0}}}'
   end
 end


### PR DESCRIPTION
Coinbase sends a total_original parameter if a gateway discount is set.  If this parameter is present, it should be used for calculating the order's total.