### PR TITLE
Bump acive_utils to 3.0, update namespace

### DIFF
--- a/lib/offsite_payments/helper.rb
+++ b/lib/offsite_payments/helper.rb
@@ -90,9 +90,9 @@ module OffsitePayments #:nodoc:
     end
 
     def lookup_country_code(name_or_code, format = country_format)
-      country = ActiveMerchant::Country.find(name_or_code)
+      country = ActiveUtils::Country.find(name_or_code)
       country.code(format).to_s
-    rescue ActiveMerchant::InvalidCountryCodeError
+    rescue ActiveUtils::InvalidCountryCodeError
       name_or_code
     end
 

--- a/lib/offsite_payments/integrations/a1agregator.rb
+++ b/lib/offsite_payments/integrations/a1agregator.rb
@@ -213,7 +213,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Status
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         STATUS_TEST_URL = 'https://partner.a1pay.ru/a1lite/info/'
 

--- a/lib/offsite_payments/integrations/chronopay.rb
+++ b/lib/offsite_payments/integrations/chronopay.rb
@@ -117,10 +117,10 @@ module OffsitePayments #:nodoc:
         private
 
         def checkout_language_from_country(country_code)
-          country    = ActiveMerchant::Country.find(country_code)
+          country    = ActiveUtils::Country.find(country_code)
           short_code = country.code(:alpha2).to_s
           LANG_FOR_COUNTRY[short_code]
-        rescue ActiveMerchant::InvalidCountryCodeError
+        rescue ActiveUtils::InvalidCountryCodeError
           'EN'
         end
       end

--- a/lib/offsite_payments/integrations/direc_pay.rb
+++ b/lib/offsite_payments/integrations/direc_pay.rb
@@ -309,7 +309,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Status
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         STATUS_TEST_URL = 'https://test.direcpay.com/direcpay/secure/dpMerchantTransaction.jsp'
         STATUS_LIVE_URL = 'https://www.timesofmoney.com/direcpay/secure/dpPullMerchAtrnDtls.jsp'
@@ -324,7 +324,7 @@ module OffsitePayments #:nodoc:
         def update(authorization, notification_url)
           url = test? ? STATUS_TEST_URL : STATUS_LIVE_URL
           parameters = [ authorization, account, notification_url ]
-          data = ActiveMerchant::PostData.new
+          data = ActiveUtils::PostData.new
           data[:requestparams] = parameters.join('|')
 
           response = ssl_get("#{url}?#{data.to_post_data}")

--- a/lib/offsite_payments/integrations/dotpay.rb
+++ b/lib/offsite_payments/integrations/dotpay.rb
@@ -75,9 +75,9 @@ module OffsitePayments #:nodoc:
         private
 
         def lookup_country_code(name_or_code, format = country_format)
-          country = ActiveMerchant::Country.find(name_or_code)
+          country = ActiveUtils::Country.find(name_or_code)
           country.code(format).to_s
-        rescue ActiveMerchant::InvalidCountryCodeError
+        rescue ActiveUtils::InvalidCountryCodeError
           name_or_code
         end
       end

--- a/lib/offsite_payments/integrations/e_payment_plans.rb
+++ b/lib/offsite_payments/integrations/e_payment_plans.rb
@@ -67,7 +67,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Notification < OffsitePayments::Notification
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
         def complete?
           status == "Completed"
         end

--- a/lib/offsite_payments/integrations/ipay88.rb
+++ b/lib/offsite_payments/integrations/ipay88.rb
@@ -20,7 +20,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Helper < OffsitePayments::Helper
-        include ActiveMerchant::RequiresParameters
+        include ActiveUtils::RequiresParameters
 
         # Currencies supported
         #   MYR (Malaysian Ringgit - for all payment methods except China Union Pay and PayPal)
@@ -130,7 +130,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Notification < OffsitePayments::Notification
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         def status
           if params["Status"] == '1'

--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -2,7 +2,7 @@ module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module MollieIdeal
       class API
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         attr_reader :token
 
@@ -25,7 +25,7 @@ module OffsitePayments #:nodoc:
         end
       end
 
-      RedirectError = Class.new(ActiveMerchant::ActiveMerchantError)
+      RedirectError = Class.new(ActiveUtils::ActiveUtilsError)
 
       MOLLIE_API_V1_URI = 'https://api.mollie.nl/v1/'.freeze
 
@@ -137,7 +137,7 @@ module OffsitePayments #:nodoc:
 
         def request_redirect
           MollieIdeal.create_payment(token, redirect_paramaters)
-        rescue ActiveMerchant::ResponseError => e
+        rescue ActiveUtils::ResponseError => e
           case e.response.code
           when '401', '403', '422'
             error = JSON.parse(e.response.body)['error']['message']

--- a/lib/offsite_payments/integrations/nochex.rb
+++ b/lib/offsite_payments/integrations/nochex.rb
@@ -139,7 +139,7 @@ module OffsitePayments #:nodoc:
 
       # Parser and handler for incoming Automatic Payment Confirmations from Nochex.
       class Notification < OffsitePayments::Notification
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         def complete?
           status == 'Completed'

--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -134,7 +134,7 @@ module OffsitePayments #:nodoc:
           when "401"
             raise ActionViewHelperError, "Token do PagSeguro inválido."
           else
-            raise ActiveMerchant::ResponseError, response
+            raise ActiveUtils::ResponseError, response
           end
         end
 

--- a/lib/offsite_payments/integrations/pay_fast.rb
+++ b/lib/offsite_payments/integrations/pay_fast.rb
@@ -172,7 +172,7 @@ module OffsitePayments #:nodoc:
       #     end
       #   end
       class Notification < OffsitePayments::Notification
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
         include Common
 
         # Was the transaction complete?

--- a/lib/offsite_payments/integrations/payflow_link.rb
+++ b/lib/offsite_payments/integrations/payflow_link.rb
@@ -13,7 +13,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Helper < OffsitePayments::Helper
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         def initialize(order, account, options = {})
           super

--- a/lib/offsite_payments/integrations/paypal.rb
+++ b/lib/offsite_payments/integrations/paypal.rb
@@ -180,7 +180,7 @@ module OffsitePayments #:nodoc:
       #     end
       #   end
       class Notification < OffsitePayments::Notification
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         def initialize(post, options = {})
           super

--- a/lib/offsite_payments/integrations/pxpay.rb
+++ b/lib/offsite_payments/integrations/pxpay.rb
@@ -16,7 +16,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Helper < OffsitePayments::Helper
-        include ActiveMerchant::PostsData
+        include ActiveUtils::PostsData
 
         attr_reader :token_parameters, :redirect_parameters
 
@@ -58,7 +58,7 @@ module OffsitePayments #:nodoc:
           end
 
           url.to_s
-        rescue ActiveMerchant::ConnectionError
+        rescue ActiveUtils::ConnectionError
           raise ActionViewHelperError, "A connection error occurred while contacting the payment gateway. Please try again."
         end
 
@@ -104,8 +104,8 @@ module OffsitePayments #:nodoc:
       end
 
       class Notification < OffsitePayments::Notification
-        include ActiveMerchant::PostsData
-        include ActiveMerchant::RequiresParameters
+        include ActiveUtils::PostsData
+        include ActiveUtils::RequiresParameters
 
         def initialize(query_string, options={})
           # PxPay appends ?result=...&userid=... to whatever return_url was specified, even if that URL ended with a ?query.

--- a/lib/offsite_payments/integrations/valitor.rb
+++ b/lib/offsite_payments/integrations/valitor.rb
@@ -24,7 +24,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Helper < OffsitePayments::Helper
-        include ActiveMerchant::RequiresParameters
+        include ActiveUtils::RequiresParameters
 
         DEFAULT_SUCCESS_TEXT = "The transaction has been completed."
 

--- a/lib/offsite_payments/notification.rb
+++ b/lib/offsite_payments/notification.rb
@@ -54,7 +54,7 @@ module OffsitePayments #:nodoc:
     end
 
     def iso_currency
-      ActiveMerchant::CurrencyCode.standardize(currency)
+      ActiveUtils::CurrencyCode.standardize(currency)
     end
 
     private

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '~> 0.5')
   s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
-  s.add_dependency('json', '~> 1.7')
-  s.add_dependency('active_utils', '~> 2.2.0')
+  s.add_dependency('active_utils', '~> 3.0.0.pre2')
   s.add_dependency('nokogiri', "~> 1.4")
   s.add_dependency('actionpack', ">= 3.2.20", "< 5.0.0")
 

--- a/test/remote/remote_mollie_ideal_test.rb
+++ b/test/remote/remote_mollie_ideal_test.rb
@@ -8,7 +8,7 @@ class RemoteMollieIdealTest < Test::Unit::TestCase
   end
 
   def test_authorization
-    assert_raises(ActiveMerchant::ResponseError) { MollieIdeal.retrieve_issuers('bad_api_key') }
+    assert_raises(ActiveUtils::ResponseError) { MollieIdeal.retrieve_issuers('bad_api_key') }
   end
 
   def test_retrieve_issuers

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_helper_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_helper_test.rb
@@ -35,7 +35,7 @@ class MollieIdealHelperTest < Test::Unit::TestCase
   def test_credential_based_url_errors
     @mock_api.expects(:post_request)
       .with('payments', :amount => 500, :description => 'Order #111', :method => 'ideal', :issuer => 'ideal_TESTNL99', :redirectUrl => 'https://return.com', :metadata => {:order => 'order-500'})
-      .raises(ActiveMerchant::ResponseError.new(stub(:code => "403", :message => "Internal Server Error", :body => '{"error": {"message": "bleh"}}')))
+      .raises(ActiveUtils::ResponseError.new(stub(:code => "403", :message => "Internal Server Error", :body => '{"error": {"message": "bleh"}}')))
 
     assert_raises ActionViewHelperError do
       @helper.credential_based_url
@@ -43,7 +43,7 @@ class MollieIdealHelperTest < Test::Unit::TestCase
   end
 
   def test_credential_based_url_server_errors
-    @mock_api.expects(:post_request).raises(ActiveMerchant::ResponseError.new(stub(:code => "503", :message => "Service Unavailable")))
+    @mock_api.expects(:post_request).raises(ActiveUtils::ResponseError.new(stub(:code => "503", :message => "Service Unavailable")))
 
     assert_raises ActionViewHelperError do
       @helper.credential_based_url

--- a/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
@@ -163,7 +163,7 @@ class PagSeguroHelperTest < Test::Unit::TestCase
   def test_fetch_token_raises_error_if_pagseguro_fails
     Net::HTTP.any_instance.expects(:request).returns(stub(code: "500", body: ""))
 
-    assert_raise ActiveMerchant::ResponseError do
+    assert_raise ActiveUtils::ResponseError do
       @helper.fetch_token
     end
   end

--- a/test/unit/integrations/pxpay/pxpay_module_test.rb
+++ b/test/unit/integrations/pxpay/pxpay_module_test.rb
@@ -79,7 +79,7 @@ class PxpayModuleTest < Test::Unit::TestCase
   end
 
   def test_credential_based_url_connection_error
-    Pxpay::Helper.any_instance.expects(:ssl_post).raises(ActiveMerchant::ConnectionError)
+    Pxpay::Helper.any_instance.expects(:ssl_post).raises(ActiveUtils::ConnectionError)
 
     helper = Pxpay::Helper.new('44', @username, @service_options.slice(:amount, :return_url, :credential2))
 

--- a/test/unit/notification_test.rb
+++ b/test/unit/notification_test.rb
@@ -53,7 +53,7 @@ class NotificationTest < Test::Unit::TestCase
     assert_equal 'TWD', CurrencyNotificationStub.new('currency=NTD').iso_currency
     assert_equal 'CNY', CurrencyNotificationStub.new('currency=rmb').iso_currency
 
-    assert_raise ActiveMerchant::InvalidCurrencyCodeError do
+    assert_raise ActiveUtils::InvalidCurrencyCodeError do
       CurrencyNotificationStub.new('currency=not_real').iso_currency
     end
   end


### PR DESCRIPTION
- Bumps ActiveUtils to 3.0 (currently in prerelease)
- Removes `json` gem dependency; it is included in the ruby standard library since 1.9.
- Update all `ActiveMerchant` code mentions to `ActiveUtils`

@karlhungus @ntalbott 