### PR TITLE
Update CHANGELOG and bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Offsite Payments CHANGELOG
 
-## Version 2.0.1 (June 6, 2014)
+### Version 2.1.0 (January 16, 2015)
 
-* Configured ShipIt for deploys to RubyGems [bslobodin]
+- **Change:** network exceptions now use ActiveUtils instead of ActiveMerchant as namespace,
+  e.g. `ActiveUtils::ConnectionError` instead of `ActiveMerchant::ConnectionError`. [wvanbergen]
+- Bump active_utils and active_support dependencies. [wvanbergen]
+- Bump test dependencies. [wvanbergen]
 
-## Version 2.0.0 (June 4, 2014)
+### Version 2.0.1 (June 6, 2014)
 
-* Extracted from ActiveMerchant [ntalbott]
+- Configured ShipIt for deploys to RubyGems [bslobodin]
+
+### Version 2.0.0 (June 4, 2014)
+
+- Extracted from ActiveMerchant [ntalbott]

--- a/lib/offsite_payments/version.rb
+++ b/lib/offsite_payments/version.rb
@@ -1,3 +1,3 @@
 module OffsitePayments
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
@girasquid I don't think a major release is necessary, so I bumped it to 2.1.0.