### PR TITLE
Adding class methods to yuupay integration

### DIFF
--- a/lib/offsite_payments/integrations/yuupay.rb
+++ b/lib/offsite_payments/integrations/yuupay.rb
@@ -2,6 +2,19 @@ module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Yuupay 
       include Universal
+
+      def self.notification(post, options = {})
+        Notification.new(post, options)
+      end
+
+      def self.return(query_string, options = {})
+        Return.new(query_string, options)
+      end
+
+      def self.sign(fields, key)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, key, fields.sort.join)
+      end
+
       class Helper < Universal::Helper
         def forward_url 
           'https://checkout.yuupay.net/payment/index.php'

--- a/test/unit/integrations/yuupay/yuupay_module_test.rb
+++ b/test/unit/integrations/yuupay/yuupay_module_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class YuupayModuleTest < Test::Unit::TestCase
+  include OffsitePayments::Integrations
+
+  def test_notification
+    assert_instance_of OffsitePayments::Notification, Yuupay.notification('name=zork')
+  end
+
+  def test_return
+    assert_instance_of OffsitePayments::Return, Yuupay.return('name=zork')
+  end
+
+  def test_sign
+    expected = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, 'zork', 'a1b2')
+    assert_equal expected, Universal.sign({:b => '2', :a => '1'}, 'zork')
+  end
+
+end


### PR DESCRIPTION
Fixes: The integration currently breaks Shopify because `Yuupay.return` doesn't exist. 

@girasquid @j-mutter review please
