### PR TITLE
Gestpay error handling

### DIFF
--- a/lib/offsite_payments/integrations/gestpay.rb
+++ b/lib/offsite_payments/integrations/gestpay.rb
@@ -189,6 +189,8 @@ module OffsitePayments #:nodoc:
           response = ssl_get(Gestpay.service_url, decryption_query_string(shop_login, encrypted_string))
           encoded_response = parse_response(response)
           parse_delimited_string(encoded_response, DELIMITER, true)
+        rescue GestpayEncryptionResponseError => e
+          { 'PAY1_TRANSACTIONRESULT' => 'Error' }
         end
 
         def decryption_query_string(shop_login, encrypted_string)

--- a/test/unit/integrations/gestpay/gestpay_notification_test.rb
+++ b/test/unit/integrations/gestpay/gestpay_notification_test.rb
@@ -49,6 +49,16 @@ class GestpayNotificationTest < Test::Unit::TestCase
     assert_equal '1000', notification.item_id
   end
 
+  def test_error_notification
+    Gestpay::Notification.any_instance.expects(:ssl_get).returns(unencrypted_string)
+    Gestpay::Notification.any_instance.expects(:parse_response).raises(OffsitePayments::Integrations::Gestpay::Common::GestpayEncryptionResponseError.new)
+
+    assert_nothing_raised do
+      notification = Gestpay::Notification.new(raw_query_string)
+      refute notification.complete?
+    end
+  end
+
   private
   def raw_query_string
     "a=900000&b=F7DEB36478FD84760F9134F23C922697272D57DE6D4518EB9B4D468B769D9A3A8071B6EB160B35CB412FC1820C7CC12D17B3141855B1ED55468613702A2E213DDE9DE5B0209E13C416448AE833525959F05693172D7F0656"


### PR DESCRIPTION
Currently, the Notification for Gestpay will [raise a GestpayEncryptionResponseError if the server tells us there was an error](https://github.com/Shopify/offsite_payments/blob/master/lib/offsite_payments/integrations/gestpay.rb#L40-L41). 

This is handled [in the helper](https://github.com/Shopify/offsite_payments/blob/master/lib/offsite_payments/integrations/gestpay.rb#L107-L112), but not in the notification, so we end up throwing exceptions instead of marking the transaction as failed. I just set the [`status` as anything other than successful](https://github.com/Shopify/offsite_payments/blob/master/lib/offsite_payments/integrations/gestpay.rb#L154-L161), which is then detected as a failure, instead of blowing up.

@aprofeit @wvanbergen 