### PR TITLE
DirecPay stops treating failed payments as pending

### DIFF
--- a/lib/offsite_payments/integrations/direc_pay.rb
+++ b/lib/offsite_payments/integrations/direc_pay.rb
@@ -289,7 +289,7 @@ module OffsitePayments #:nodoc:
 
       class Return < OffsitePayments::Return
         def initialize(post_data, options = {})
-          @notification = Notification.new(treat_failure_as_pending(post_data), options)
+          @notification = Notification.new(post_data, options)
         end
 
         def success?
@@ -298,13 +298,6 @@ module OffsitePayments #:nodoc:
 
         def message
           notification.status
-        end
-
-        private
-
-        # Work around the issue that the initial return from DirecPay is always either SUCCESS or FAIL, there is no PENDING
-        def treat_failure_as_pending(post_data)
-          post_data.sub(/FAIL/, 'PENDING')
         end
       end
 

--- a/test/unit/integrations/direc_pay/direc_pay_return_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_return_test.rb
@@ -6,18 +6,16 @@ class DirecPayReturnTest < Test::Unit::TestCase
   def test_success
     direc_pay = DirecPay::Return.new(http_raw_data_success)
     assert direc_pay.success?
+    assert direc_pay.notification.complete?
     assert_equal 'Completed', direc_pay.message
   end
 
-  def test_failure_is_successful
+  def test_failure
     direc_pay = DirecPay::Return.new(http_raw_data_failure)
-    assert direc_pay.success?
-    assert_equal 'Pending', direc_pay.message
-  end
-
-  def test_treat_initial_failures_as_pending
-    direc_pay = DirecPay::Return.new(http_raw_data_failure)
-    assert_equal 'Pending', direc_pay.notification.status
+    refute direc_pay.success?
+    refute direc_pay.notification.complete?
+    assert_equal 'Failed', direc_pay.message
+    assert_equal 'Failed', direc_pay.notification.status
   end
 
   def test_return_has_notification
@@ -34,11 +32,6 @@ class DirecPayReturnTest < Test::Unit::TestCase
     assert_equal 'INR', notification.currency
     assert_equal 'IND', notification.country
     assert_equal 'NULL', notification.other_details
-  end
-
-  def test_treat_failed_return_as_complete
-    direc_pay = DirecPay::Return.new(http_raw_data_failure)
-    assert direc_pay.notification.complete?
   end
 
   private


### PR DESCRIPTION
Failed payments are currently considered as pending. Based on latest documentation (link?), it should now be safe not to do this.

@j-mutter @volmer @andrewpaliga @silverstreaked 