### PR TITLE
Allow checkout tokens to be passed into forms

### DIFF
--- a/lib/offsite_payments/helper.rb
+++ b/lib/offsite_payments/helper.rb
@@ -16,7 +16,7 @@ module OffsitePayments #:nodoc:
     end
 
     def initialize(order, account, options = {})
-      options.assert_valid_keys([:amount, :currency, :test, :credential2, :credential3, :credential4, :country, :account_name, :description, :transaction_type, :authcode, :notify_url, :return_url, :redirect_param, :forward_url])
+      options.assert_valid_keys([:amount, :currency, :test, :credential2, :credential3, :credential4, :country, :account_name, :description, :transaction_type, :authcode, :notify_url, :return_url, :redirect_param, :forward_url, :checkout_token])
       @fields             = {}
       @raw_html_fields    = []
       @test               = options[:test]
@@ -30,6 +30,7 @@ module OffsitePayments #:nodoc:
       self.notify_url     = options[:notify_url]
       self.return_url     = options[:return_url]
       self.redirect_param = options[:redirect_param]
+      self.checkout_token = options[:checkout_token]
     end
 
     def self.mapping(attribute, options = {})

--- a/lib/offsite_payments/integrations/klarna.rb
+++ b/lib/offsite_payments/integrations/klarna.rb
@@ -2,7 +2,7 @@ module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Klarna
       mattr_accessor :service_url
-      self.service_url = 'https://api.hostedcheckout.io/api/v1/checkout'
+      self.service_url = 'https://hpp-test.herokuapp.com/shopify/payment'
 
       def self.notification(post_body, options = {})
         Notification.new(post_body, options)

--- a/test/unit/integrations/klarna/klarna_helper_test.rb
+++ b/test/unit/integrations/klarna/klarna_helper_test.rb
@@ -12,7 +12,8 @@ class KlarnaHelperTest < Test::Unit::TestCase
       :country          => 'SE',
       :account_name     => 'Example Shop Name',
       :credential2      => 'Example shared secret',
-      :test             => false
+      :test             => false,
+      :checkout_token   => 'abc123'
     }
 
     @helper = Klarna::Helper.new(@order_id, @credential1, @options)
@@ -33,6 +34,7 @@ class KlarnaHelperTest < Test::Unit::TestCase
     assert_field 'purchase_currency', @options[:currency]
     assert_field 'merchant_id', @credential1
     assert_field 'platform_type', @helper.application_id
+    assert_field 'checkout_token', @options[:token]
   end
 
   def test_customer_fields


### PR DESCRIPTION
Exactly what the title says, plus updates the Klarna endpoint.

@christianblais @girasquid 