### PR TITLE
Rescue on JSON Parse error

### DIFF
--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -122,6 +122,8 @@ module OffsitePayments #:nodoc:
         def parse(post)
           @raw = post.to_s
           @params = JSON.parse(post)['order']
+        rescue JSON::ParserError
+          @params = {}
         end
       end
 

--- a/test/unit/integrations/coinbase/coinbase_notification_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_notification_test.rb
@@ -32,6 +32,26 @@ class CoinbaseNotificationTest < Test::Unit::TestCase
     assert !@coinbase.acknowledge
   end
 
+  def test_params_with_empty_data
+    coinbase = Coinbase::Notification.new('')
+    assert_empty coinbase.params
+  end
+
+  def test_params_with_invalid_data
+    coinbase = Coinbase::Notification.new('{"invalid": json}')
+    assert_empty coinbase.params
+  end
+
+  def test_acknowledgement_with_empty_data
+    Net::HTTP.any_instance.expects(:request).returns(stub(body: ''))
+    refute @coinbase.acknowledge
+  end
+
+  def test_acknowledgement_with_invalid_data
+    Net::HTTP.any_instance.expects(:request).returns(stub(body: '{"invalid": json}'))
+    refute @coinbase.acknowledge
+  end
+
   private
 
   def http_raw_data


### PR DESCRIPTION
Added error handling on invalid or empty JSON payload for the Coinbase Notification Integration.

Tested `params` and `acknowledge`, as both will use `parse` (`params` will be parsed through the constructor though).

Please review @andrewpaliga @masaruhoshi 