### PR TITLE
fix bug - order is not string

### DIFF
--- a/lib/offsite_payments/integrations/realex.rb
+++ b/lib/offsite_payments/integrations/realex.rb
@@ -118,7 +118,7 @@ module OffsitePayments #:nodoc:
           # however it does echo any other param so we send it twice.
           add_field 'X-CURRENCY', @currency
           add_field 'X-TEST', @test.to_s
-          add_field 'ORDER_ID', order + @timestamp.to_i.to_s
+          add_field 'ORDER_ID', "#{order}#{@timestamp.to_i}"
         end
 
         def form_fields

--- a/test/unit/integrations/realex/realex_module_test.rb
+++ b/test/unit/integrations/realex/realex_module_test.rb
@@ -4,7 +4,7 @@ class RealexModuleTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def test_helper_method
-    assert_instance_of Realex::Helper, Realex.helper('123', 'test')
+    assert_instance_of Realex::Helper, Realex.helper(123, 'test')
   end
 
   def test_return_method


### PR DESCRIPTION
Shopify passes in `order` as an integer. 

@girasquid @ivanfer 