### PR TITLE
Do not send credential3 with when it is the forward URL

### DIFF
--- a/lib/offsite_payments/integrations/universal.rb
+++ b/lib/offsite_payments/integrations/universal.rb
@@ -50,6 +50,10 @@ module OffsitePayments #:nodoc:
           @forward_url = options[:forward_url]
           @key = options[:credential2]
           @currency = options[:currency]
+
+          # x_credential3 should not be included in the request when using the universal offsite dev kit.
+          options[:credential3] = nil if options[:credential3] == @forward_url
+
           super
           self.country = options[:country]
           self.account_name = options[:account_name]

--- a/test/unit/integrations/universal/universal_helper_test.rb
+++ b/test/unit/integrations/universal/universal_helper_test.rb
@@ -138,4 +138,12 @@ class UniversalHelperTest < Test::Unit::TestCase
 
     assert_field 'x_signature', expected_signature
   end
+
+  def test_credential3_not_sent_when_using_universal_offsite_dev_kit
+    @options[:credential3] = 'https://offsite-gateway-sim.herokuapp.com/'
+    @options[:forward_url] = 'https://offsite-gateway-sim.herokuapp.com/'
+    @helper = Universal::Helper.new(@order, @account, @options)
+
+    assert_field 'x_credential3', nil
+  end
 end


### PR DESCRIPTION
@andrewpaliga @girasquid for review.

This should be reverted once the Universal Offsite Dev Kit is not needed anymore.